### PR TITLE
Add empty comment at end of app-routing.module.ts

### DIFF
--- a/redbarrio/src/app/app-routing.module.ts
+++ b/redbarrio/src/app/app-routing.module.ts
@@ -110,3 +110,4 @@ const routes: Routes = [
 export class AppRoutingModule {}
 
 
+/**/


### PR DESCRIPTION
An empty comment (/* */) was added at the end of the app-routing.module.ts file. No functional changes were made.